### PR TITLE
Always attempt to pull a newer version of the baseimage when building

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -78,7 +78,7 @@ fi
 # Build
 echo "Building Sherpa containers..."
 docker-compose -f ${COMPOSE_FILE} -p ${NEW_SHA} pull
-docker-compose -f ${COMPOSE_FILE} -p ${NEW_SHA} build
+docker-compose -f ${COMPOSE_FILE} -p ${NEW_SHA} build --pull
 
 # Hard deployments: remove the current backend before migrating
 if [[ -n ${OLD_SHA} && "$DEPLOYMENT_METHOD" = "hard" ]]; then


### PR DESCRIPTION
This ensures that all Sherpa containers use the latest version of their base images when deploying new versions:
- [sherpa/Dockerfile](https://github.com/Turistforeningen/sherpa/blob/master/Dockerfile) - `python:2.7`
- [sherpa/nginx/Dockerfile](https://github.com/Turistforeningen/sherpa/blob/master/nginx/Dockerfile) - `nginx:1.9`
- [sherpa/builder/Dockerfile](https://github.com/Turistforeningen/sherpa/blob/master/builder/Dockerfile) - `node:argon`
